### PR TITLE
replacing the odd 'C withe the more common °C

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -18,7 +18,7 @@ module.exports = NodeHelper.create({
 				console.log(error);
 				return;
 			}
-	  		self.sendSocketNotification('TEMPERATURE', stdout.replace('temp=',''));
+	  		self.sendSocketNotification('TEMPERATURE', stdout.replace('temp=','').replace('\'','\°'));
 		});
 	}
 });


### PR DESCRIPTION
Instead of just removing the "temp=" from the readout this will also
replace ' with ° for the more common notation of the temperature in
Celsius.