### PR TITLE
remove unused sys variable ...

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -1,5 +1,4 @@
 var NodeHelper = require("node_helper");
-var sys = require('sys');
 var exec = require('child_process').exec;
 
 


### PR DESCRIPTION
… which causes 

`[ERROR]  (node:331) [DEP0025] DeprecationWarning: sys is deprecated. Use util instead.`