### PR TITLE
vcgencmd binary not under /opt/vc in arm64, update lodash, run prettier

### DIFF
--- a/mmm-systemtemperature.css
+++ b/mmm-systemtemperature.css
@@ -1,4 +1,4 @@
 .mmm-systemtemperature .temperatureUnit::before {
-    content: '°';
-    display: inline;    
+  content: "°";
+  display: inline;
 }

--- a/mmm-systemtemperature.js
+++ b/mmm-systemtemperature.js
@@ -1,84 +1,99 @@
-Module.register("mmm-systemtemperature",{
+Module.register("mmm-systemtemperature", {
+  defaults: {
+    prependString: "System temperature: ",
+    updateInterval: 5000,
+    animationSpeed: 0,
+    unit: "c",
+    warning: { temp: 60, color: "orange", command: undefined },
+    critical: {
+      temp: 75,
+      color: "red",
+      command: {
+        notification: "REMOTE_ACTION",
+        payload: { action: "SHUTDOWN" },
+      },
+    },
+  },
 
-	defaults: {
-		prependString: 'System temperature: ',
-		updateInterval: 5000,
-		animationSpeed: 0,
-		unit: 'c',
-		warning: { temp: 60, color: 'orange', command: undefined },
-		critical:  { temp: 75, color: 'red', command: { notification: 'REMOTE_ACTION', payload: { action: 'SHUTDOWN' } } }
-	},
+  getStyles: function () {
+    return ["mmm-systemtemperature.css", "font-awesome.css"];
+  },
 
-	getStyles: function () {
-	  return ["mmm-systemtemperature.css", "font-awesome.css"];
-	},
+  getScripts: function () {
+    return [`modules/${this.name}/node_modules/lodash/lodash.js`];
+  },
 
-	getScripts: function () {
-	  return [`modules/${this.name}/node_modules/lodash/lodash.js`];
-	},
+  start: function () {
+    this.sendSocketNotification("CONFIG", this.config);
+    this.config.unit = this.config.unit && this.config.unit.toLowerCase();
+    this.commandExecutor = this.getCommandExecutor();
+  },
 
-	start: function() {
-		this.sendSocketNotification('CONFIG', this.config);
-		this.config.unit = this.config.unit && this.config.unit.toLowerCase();
-		this.commandExecutor = this.getCommandExecutor();
-	},
+  socketNotificationReceived: function (notification, payload) {
+    if (notification === "TEMPERATURE") {
+      this.temperature = parseFloat(payload);
+      this.stateConfig = this.getStateConfigByTemperature() || {};
+      this.updateDom(this.config.animationSpeed);
+      this.commandExecutor();
+    }
+  },
 
-	socketNotificationReceived: function(notification, payload) {
-	    if (notification === 'TEMPERATURE') {
-			this.temperature = parseFloat(payload);
-			this.stateConfig = this.getStateConfigByTemperature() || {};
-			this.updateDom(this.config.animationSpeed);
-			this.commandExecutor();
-	    }
-	},
+  getDom: function () {
+    var wrapper = document.createElement("div");
+    if (this.temperature) {
+      wrapper.innerHTML =
+        this.config.prependString + this.getTemperatureLabel();
+      wrapper.style.color = this.stateConfig.color || "";
+    } else {
+      wrapper.innerHTML = `<i class="fas fa-spinner fa-spin"></i> ${this.translate(
+        "LOADING"
+      )}`;
+    }
+    return wrapper;
+  },
 
-	getDom: function() {
-		var wrapper = document.createElement("div");
-		if (this.temperature) {
-			wrapper.innerHTML = this.config.prependString + this.getTemperatureLabel();
-			wrapper.style.color = this.stateConfig.color || "";
-		} else {
-			wrapper.innerHTML = `<i class="fas fa-spinner fa-spin"></i> ${this.translate("LOADING")}`;
-		}
-		return wrapper;
-	},
-
-	getTemperatureLabel: function() {
-		return `<span class="temperatureLabel">
+  getTemperatureLabel: function () {
+    return `<span class="temperatureLabel">
 					<span class="temperatureValue">${this.getConvertedTemperature()}</span> 
 					<span class="temperatureUnit">${this.config.unit.toUpperCase()}</span>
 				</span>`;
-	},
+  },
 
-	getStateConfigByTemperature: function() {
-		if (this.config.critical && this.temperature >= this.config.critical.temp) {
-			return this.config.critical;
-		} else if (this.config.warning && this.temperature >= this.config.warning.temp) {
-			return this.config.warning;
-		}
-	},
+  getStateConfigByTemperature: function () {
+    if (this.config.critical && this.temperature >= this.config.critical.temp) {
+      return this.config.critical;
+    } else if (
+      this.config.warning &&
+      this.temperature >= this.config.warning.temp
+    ) {
+      return this.config.warning;
+    }
+  },
 
-	getConvertedTemperature: function() {
-		if (this.temperature && this.config.unit !== 'c') {
-			var convertedTemperature;
-			if (this.config.unit === 'f') {
-				convertedTemperature = this.temperature * 9 / 5 + 32;
-			} else if (this.config.unit === 'k') {
-				convertedTemperature = this.temperature - 273.15;
-			}
-			// Round off the temperature to 2 decimal places
-			return Math.round(convertedTemperature * 100) / 100;
-		}
-		return this.temperature;
-	},
+  getConvertedTemperature: function () {
+    if (this.temperature && this.config.unit !== "c") {
+      var convertedTemperature;
+      if (this.config.unit === "f") {
+        convertedTemperature = (this.temperature * 9) / 5 + 32;
+      } else if (this.config.unit === "k") {
+        convertedTemperature = this.temperature - 273.15;
+      }
+      // Round off the temperature to 2 decimal places
+      return Math.round(convertedTemperature * 100) / 100;
+    }
+    return this.temperature;
+  },
 
-	getCommandExecutor: function() {
-		return _.throttle(() => {
-			if (this.stateConfig && this.stateConfig.command) {
-				const command = this.stateConfig.command;
-				this.sendNotification(command.notification, command.payload);
-			}
-		}, this.config.updateInterval * 5, { leading: false, trailing: true });
-	}
-
+  getCommandExecutor: function () {
+    return _.throttle(
+      () => {
+        if (this.stateConfig && this.stateConfig.command) {
+          const command = this.stateConfig.command;
+          this.sendNotification(command.notification, command.payload);
+        }
+      },
+      this.config.updateInterval * 5,
+      { leading: false, trailing: true }
+    );
+  },
 });

--- a/node_helper.js
+++ b/node_helper.js
@@ -1,28 +1,35 @@
 var NodeHelper = require("node_helper");
-var exec = require('child_process').exec;
+var exec = require("child_process").exec;
 
 module.exports = NodeHelper.create({
-	start: function() {
-		console.log("Starting node helper: " + this.name);
-	},
+  start: function () {
+    console.log("Starting node helper: " + this.name);
+  },
 
-	// Subclass socketNotificationReceived received.
-	socketNotificationReceived: function(notification, payload) {
-		if (notification === 'CONFIG') {
-			this.config = payload;
-			setInterval(() => {
-				this.sendTemperature();
-			}, this.config.updateInterval);
-		}
-	},
+  // Subclass socketNotificationReceived received.
+  socketNotificationReceived: function (notification, payload) {
+    if (notification === "CONFIG") {
+      this.config = payload;
+      setInterval(() => {
+        this.sendTemperature();
+      }, this.config.updateInterval);
+    }
+  },
 
-	sendTemperature: function() {
-		exec("/opt/vc/bin/vcgencmd measure_temp", (error, stdout, stderr) => {
-			if (error) {
-				console.log(error);
-				return;
-			}
-			this.sendSocketNotification('TEMPERATURE', parseFloat(stdout.replace('temp=','')));
-		});
-	}
+  sendTemperature: function () {
+    let cmd = "/opt/vc/bin/vcgencmd measure_temp";
+    if (process.arch === "arm64") {
+      cmd = "vcgencmd measure_temp";
+    }
+    exec(cmd, (error, stdout, stderr) => {
+      if (error) {
+        console.log(error);
+        return;
+      }
+      this.sendSocketNotification(
+        "TEMPERATURE",
+        parseFloat(stdout.replace("temp=", ""))
+      );
+    });
+  },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,28 @@
 {
   "name": "mmm-systemtemperature",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "mmm-systemtemperature",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": ">=4.17.21"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    }
+  },
   "dependencies": {
     "lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "lodash": ">=4.17.19"
+    "lodash": ">=4.17.21"
   }
 }


### PR DESCRIPTION
Using the new 64-bit raspian os the whole stuff before lying under `/opt/vc` is now integrated under normal locations.

`vcgencmd` is under `/usr/bin` and therefore in the PATH. So main change is to omit `/opt/vc` if arch = `arm64`.

Beside I bumped lodash to newest version and ran prettier.