### PR TITLE
Fix broken path to vcgencmd on Raspbian 64 bit

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -1,5 +1,6 @@
 var NodeHelper = require("node_helper");
 var exec = require('child_process').exec;
+var fs = require('fs');
 
 module.exports = NodeHelper.create({
 	start: function() {
@@ -17,7 +18,15 @@ module.exports = NodeHelper.create({
 	},
 
 	sendTemperature: function() {
-		exec("/opt/vc/bin/vcgencmd measure_temp", (error, stdout, stderr) => {
+		var command = "/opt/vc/bin/vcgencmd measure_temp"
+		
+		// Since on 64 bit OS's like Raspbian, path to vcgencmd is different 
+		// we need to adjust it accordingly
+		if (fs.existsSync(path) === false) {
+		  command = "/usr/bin/vcgencmd measure_temp"
+		}
+		
+		exec(command, (error, stdout, stderr) => {
 			if (error) {
 				console.log(error);
 				return;


### PR DESCRIPTION
Path to `vcgencmd` utility on Raspbian 64 bit is changed to `/usr/bin/vcgencmd` instead of `/opt/vc/bin/vcgencmd`.
This pull request checks path in both locations and runs it accordingly.